### PR TITLE
Request POD from metacpan, not the module source

### DIFF
--- a/lib/Pod/Cpandoc.pm
+++ b/lib/Pod/Cpandoc.pm
@@ -12,7 +12,11 @@ sub live_cpan_url {
     my $self   = shift;
     my $module = shift;
 
-    return "http://api.metacpan.org/pod/$module?content-type=text/x-pod";
+    if ($self->opt_m) {
+        return "http://api.metacpan.org/source/$module";
+    } else {
+        return "http://api.metacpan.org/pod/$module?content-type=text/x-pod";
+    }
 }
 
 sub unlink_tempfiles {


### PR DESCRIPTION
The module source doesn't always contain POD, if for example, there's a
corresponding .pod file of the same name.  Let metacpan sort it out for
us.

Avoids errors like this:

```
tom@whaam rt-review (4.0/upgrading-formatting) $ perldoc XML::Compile
Fetching http://api.metacpan.org/source/XML::Compile
Got a 0-length file from /tmp/XML-Compile-jIRx.pm via Pod::Perldoc::ToMan!?
```
